### PR TITLE
Add queue options to producer

### DIFF
--- a/src/fiunchinho/Silex/Provider/RabbitServiceProvider.php
+++ b/src/fiunchinho/Silex/Provider/RabbitServiceProvider.php
@@ -88,6 +88,7 @@ class RabbitServiceProvider implements ServiceProviderInterface
 
                 $producer = new Producer($connection);
                 $producer->setExchangeOptions($options['exchange_options']);
+		$producer->setQueueOptions($options['queue_options']);
 
                 if ((array_key_exists('auto_setup_fabric', $options)) && (!$options['auto_setup_fabric'])) {
                     $producer->disableAutoSetupFabric();


### PR DESCRIPTION
Hi Jose!
This is the first day that I play around with rabbitMQ and so I´m not finally sure if I´m using the service provider wrong or wether this is a bug. By using your version all messages are sent to rabbit in anonymous channels (amq.gen-foobar). When I add my options via setQueueOptions to the producer (like it is done for the consumer) all messages are sent to the channel from my options as expected. 
