### PR TITLE
use stable dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.4.0",
         "silex/silex": "~1.2",
         "oldsound/rabbitmq-bundle": "~1.5",
-        "knplabs/console-service-provider": "dev-master"
+        "knplabs/console-service-provider": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~3"


### PR DESCRIPTION
... just to avoid this error:

```
$ composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for fiunchinho/rabbitmq-service-provider ~1.0 -> satisfiable by fiunchinho/rabbitmq-service-provider[1.0.0].
    - fiunchinho/rabbitmq-service-provider 1.0.0 requires knplabs/console-service-provider dev-master -> no matching package found.

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.

Read <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
```
