### PR TITLE
Adapt to Silex 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,13 @@ $app->register(new RabbitServiceProvider(), [
     'rabbit.producers' => [
         'first_producer' => [
             'connection'        => 'another',
-            'exchange_options'  => ['name' => 'a_exchange', 'type' => 'topic']
+            'exchange_options'  => ['name' => 'a_exchange', 'type' => 'topic'],
+            'queue_options'     => ['name' => 'a_queue', 'routing_keys' => ['foo.#']]
         ],
         'second_producer' => [
             'connection'        => 'default',
             'exchange_options'  => ['name' => 'a_exchange', 'type' => 'topic']
+            'queue_options'     => ['name' => 'another_queue', 'routing_keys' => ['foo.#']]
         ],
     ],
     'rabbit.consumers' => [

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,15 @@
             "homepage": "http://blog.armesto.net"
         }
     ],
-    "require-dev": {
+    "require": {
         "silex/silex": "~2.0@dev",
         "oldsound/rabbitmq-bundle": "~1.5",
         "knplabs/console-service-provider": "~1.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~4.2"
+    },
     "autoload": {
         "psr-0": { "fiunchinho": "src/" }
-    },
-    "minimum-stability": "dev"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,13 @@
             "homepage": "http://blog.armesto.net"
         }
     ],
-    "require": {
-        "php": ">=5.4.0",
-        "silex/silex": "~1.2",
+    "require-dev": {
+        "silex/silex": "~2.0@dev",
         "oldsound/rabbitmq-bundle": "~1.5",
         "knplabs/console-service-provider": "~1.0"
     },
-    "require-dev": {
-        "phpunit/phpunit": "~4.2"
-    },
     "autoload": {
         "psr-0": { "fiunchinho": "src/" }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/src/fiunchinho/Silex/Provider/RabbitServiceProvider.php
+++ b/src/fiunchinho/Silex/Provider/RabbitServiceProvider.php
@@ -2,31 +2,32 @@
 
 namespace fiunchinho\Silex\Provider;
 
+use Pimple\ServiceProviderInterface;
+use Pimple\Container;
 use Silex\Application;
-use Silex\ServiceProviderInterface;
-use Symfony\Component\Routing\Generator\UrlGenerator;
+use Silex\Api\BootableProviderInterface;
+
 use OldSound\RabbitMqBundle\RabbitMq\Producer;
 use OldSound\RabbitMqBundle\RabbitMq\Consumer;
 use OldSound\RabbitMqBundle\RabbitMq\AnonConsumer;
 use OldSound\RabbitMqBundle\RabbitMq\MultipleConsumer;
 use OldSound\RabbitMqBundle\RabbitMq\RpcClient;
 use OldSound\RabbitMqBundle\RabbitMq\RpcServer;
-use PhpAmqpLib\Connection\AMQPConnection;
 use PhpAmqpLib\Connection\AMQPLazyConnection;
 
-class RabbitServiceProvider implements ServiceProviderInterface
+class RabbitServiceProvider implements ServiceProviderInterface, BootableProviderInterface
 {
     const DEFAULT_CONNECTION = 'default';
 
-    public function register(Application $app)
+    public function register(Container $container)
     {
-        $this->loadConnections($app);
-        $this->loadProducers($app);
-        $this->loadConsumers($app);
-        $this->loadAnonymousConsumers($app);
-        $this->loadMultipleConsumers($app);
-        $this->loadRpcClients($app);
-        $this->loadRpcServers($app);
+        $this->loadConnections($container);
+        $this->loadProducers($container);
+        $this->loadConsumers($container);
+        $this->loadAnonymousConsumers($container);
+        $this->loadMultipleConsumers($container);
+        $this->loadRpcClients($container);
+        $this->loadRpcServers($container);
     }
 
     public function boot(Application $app)
@@ -53,7 +54,7 @@ class RabbitServiceProvider implements ServiceProviderInterface
 
     private function loadConnections($app)
     {
-        $app['rabbit.connection'] = $app->share(function ($app) {
+        $app['rabbit.connection'] = ( function () use ($app) {
             if (!isset($app['rabbit.connections'])) {
                 throw new \InvalidArgumentException('You need to specify at least a connection in your configuration.');
             }
@@ -77,7 +78,7 @@ class RabbitServiceProvider implements ServiceProviderInterface
 
     private function loadProducers($app)
     {
-        $app['rabbit.producer'] = $app->share(function ($app) {
+        $app['rabbit.producer'] = ( function () use ($app) {
             if (!isset($app['rabbit.producers'])) {
                 return;
             }
@@ -88,6 +89,9 @@ class RabbitServiceProvider implements ServiceProviderInterface
 
                 $producer = new Producer($connection);
                 $producer->setExchangeOptions($options['exchange_options']);
+                if (array_key_exists('queue_options', $options)) {
+                    $producer->setQueueOptions($options['queue_options']);
+                }
 
                 if ((array_key_exists('auto_setup_fabric', $options)) && (!$options['auto_setup_fabric'])) {
                     $producer->disableAutoSetupFabric();
@@ -95,14 +99,13 @@ class RabbitServiceProvider implements ServiceProviderInterface
 
                 $producers[$name] = $producer;
             }
-
             return $producers;
         });
     }
 
     private function loadConsumers($app)
     {
-        $app['rabbit.consumer'] = $app->share(function ($app) {
+        $app['rabbit.consumer'] = ( function () use ($app) {
             if (!isset($app['rabbit.consumers'])) {
                 return;
             }
@@ -140,7 +143,7 @@ class RabbitServiceProvider implements ServiceProviderInterface
 
     private function loadAnonymousConsumers($app)
     {
-        $app['rabbit.anonymous_consumer'] = $app->share(function ($app) {
+        $app['rabbit.anonymous_consumer'] = ( function () use ($app) {
             if (!isset($app['rabbit.anon_consumers'])) {
                 return;
             }
@@ -161,7 +164,7 @@ class RabbitServiceProvider implements ServiceProviderInterface
 
     private function loadMultipleConsumers($app)
     {
-        $app['rabbit.multiple_consumer'] = $app->share(function ($app) {
+        $app['rabbit.multiple_consumer'] = ( function () use ($app) {
             if (!isset($app['rabbit.multiple_consumers'])) {
                 return;
             }
@@ -199,7 +202,7 @@ class RabbitServiceProvider implements ServiceProviderInterface
 
     private function loadRpcClients($app)
     {
-        $app['rabbit.rpc_client'] = $app->share(function ($app) {
+        $app['rabbit.rpc_client'] = ( function () use ($app) {
             if (!isset($app['rabbit.rpc_clients'])) {
                 return;
             }
@@ -222,7 +225,7 @@ class RabbitServiceProvider implements ServiceProviderInterface
 
     private function loadRpcServers($app)
     {
-        $app['rabbit.rpc_server'] = $app->share(function ($app) {
+        $app['rabbit.rpc_server'] = ( function () use ($app) {
             if (!isset($app['rabbit.rpc_servers'])) {
                 return;
             }

--- a/tests/unit/RabbitServiceProviderTest.php
+++ b/tests/unit/RabbitServiceProviderTest.php
@@ -42,11 +42,12 @@ class RabbitServiceProviderTest extends \PHPUnit_Framework_TestCase
             'rabbit.producers' => [
                 'a_producer' => [
                     'connection'        => 'default',
-                    'exchange_options'  => ['name' => 'a_exchange', 'type' => 'topic']
+                    'exchange_options'  => ['name' => 'a_exchange', 'type' => 'topic'],
+                    'queue_options'  => ['name' => 'a_queue']
                 ],
                 'second_producer' => [
                     'connection'        => 'default',
-                    'exchange_options'  => ['name' => 'a_exchange', 'type' => 'topic']
+                    'exchange_options'  => ['name' => 'a_exchange', 'type' => 'topic'],
                 ],
             ]
         ]);


### PR DESCRIPTION
I need this rabbitmq for my Silex 2.0@dev project, so I adapted it. 
I just put the right paremeters in boot() and register() function in the provider. 
Also removed share() because it's not needed in Silex 2.0. 

I found something that appear not to be working for me: everytime I publish a message, the Producer will add a new queue with a name like: amq.gen-QZFUDW58beV-x23f5pc0UH  
So I fixed that by setting queue options when creating the producer. 
But it will still happen if you don't set the queue options. is it normal ? 

Unit tests are running. 
Let me know if I missed something. 
If you could do a v2.0 of this, or a pre-realase of a 2.0 that would be great.
Cheers.
