### PR TITLE
Stop random queues being created by producers.

### DIFF
--- a/src/fiunchinho/Silex/Provider/RabbitServiceProvider.php
+++ b/src/fiunchinho/Silex/Provider/RabbitServiceProvider.php
@@ -89,6 +89,12 @@ class RabbitServiceProvider implements ServiceProviderInterface
                 $producer = new Producer($connection);
                 $producer->setExchangeOptions($options['exchange_options']);
 
+                //this producer doesn't define a queue
+                if (!isset($options['queue_options'])) {
+                    $options['queue_options']['name'] = null;
+                }
+                $producer->setQueueOptions($options['queue_options']);
+
                 if ((array_key_exists('auto_setup_fabric', $options)) && (!$options['auto_setup_fabric'])) {
                     $producer->disableAutoSetupFabric();
                 }


### PR DESCRIPTION
This reproduces the functionality of the original Symfony Bundle. It lets you create queues in the producer configuration and will stop random queue's being created if no queues are defined.

Fixes #3 